### PR TITLE
Create temporary directory in the right subdirectories

### DIFF
--- a/src/net/robotmedia/acv/ACVApplication.java
+++ b/src/net/robotmedia/acv/ACVApplication.java
@@ -21,14 +21,21 @@ import android.app.Application;
 
 public class ACVApplication extends Application {
 
+	private static String pkgName;
+	
 	@Override
 	public void onCreate() {
 		super.onCreate();
 		final PreferencesController preferences = new PreferencesController(this);
 		preferences.legacy();
 		preferences.setMaxImageResolution();
+		
+		pkgName = this.getPackageName();
 
 		BillingManager.getInstance(this).initialize();
 	}
 
+	public static String getPkgName() {
+		return pkgName;
+	}
 }

--- a/src/net/robotmedia/acv/Constants.java
+++ b/src/net/robotmedia/acv/Constants.java
@@ -122,7 +122,7 @@ public class Constants {
 	public static final int COMPRESSION_QUALITY = 80;
 	
 	@Deprecated
-	public static String TEMP_PATH = "acv/.temp";
+	public static String TEMP_PATH = "temp";
 	
 	public static float ZOOM_STEP = 1.5f;
 	public static float MAX_ZOOM_FACTOR = 2f;

--- a/src/net/robotmedia/acv/comic/ACVComic.java
+++ b/src/net/robotmedia/acv/comic/ACVComic.java
@@ -225,7 +225,7 @@ public class ACVComic extends Comic {
 	} 
 						
 	public String getContentBaseURL() {
-		final File dir = new File(Environment.getExternalStorageDirectory(), this.getRelativePath());
+		final File dir = FileUtils.getExternalStorageDirectory(this.getRelativePath());
 		return Uri.fromFile(dir).toString() + "/";
 	}
 

--- a/src/net/robotmedia/acv/comic/Comic.java
+++ b/src/net/robotmedia/acv/comic/Comic.java
@@ -211,7 +211,7 @@ public abstract class Comic {
 	}
 	
 	protected File createTempFile(String name) {
-		File dir = new File(Environment.getExternalStorageDirectory(), this.getRelativePath());
+		File dir = FileUtils.getExternalStorageDirectory(this.getRelativePath());
 		if (id != null) {
 			dir = new File(dir, this.getID());
 		}

--- a/src/net/robotmedia/acv/ui/ComicViewerActivity.java
+++ b/src/net/robotmedia/acv/ui/ComicViewerActivity.java
@@ -1168,7 +1168,7 @@ public class ComicViewerActivity extends ExtendedActivity implements OnGestureLi
 		mScreen.recycleBitmaps();
 		
 		if (emptyTemp) {
-			File tempDirectory = new File(Environment.getExternalStorageDirectory(), Constants.TEMP_PATH);
+			File tempDirectory = FileUtils.getExternalStorageDirectory(Constants.TEMP_PATH);
 			if(tempDirectory.exists())
 				FileUtils.deleteDirectory(tempDirectory);
 		}

--- a/src/net/robotmedia/acv/utils/FileUtils.java
+++ b/src/net/robotmedia/acv/utils/FileUtils.java
@@ -17,6 +17,9 @@ package net.robotmedia.acv.utils;
 
 import java.io.File;
 
+import android.os.Environment;
+
+import net.robotmedia.acv.ACVApplication;
 import net.robotmedia.acv.Constants;
 
 public class FileUtils {
@@ -25,6 +28,15 @@ public class FileUtils {
 	private static final String EXTENSION_HTM = "htm";
 	private static final String EXTENSION_HTML = "html";
 
+	public static File getExternalStorageDirectory(String name) {
+		File storageDir = new File(Environment.getExternalStorageDirectory(),
+			"/Android/data/" + ACVApplication.getPkgName() + "/files");
+		if(!storageDir.exists())
+			storageDir.mkdirs();
+		
+		return new File(storageDir, name);
+	}
+	
 	public static String getFileExtension(String fileName) {
 		String[] splitExtension = fileName.split("\\.");
 		if (splitExtension.length > 1) {


### PR DESCRIPTION
This patch creates the temporary directory on the sdcard in the correct location. As the min sdk version for ACV is below the API Level for Context.getExternalFilesDir() I build the directory string myself.
