### PR TITLE
Allow Android file managers to open ZIPs with ACV.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -72,6 +72,26 @@
                     android:mimeType="application/x-acv"
                     android:scheme="file" >
                 </data>
+                <data
+                    android:mimeType="application/zip"
+                    android:scheme="file" >
+                </data>
+                <data 
+                     android:scheme="file"
+                     android:pathPattern=".*\\.cbr" >
+                </data>
+                <data 
+                     android:scheme="file"
+                     android:pathPattern=".*\\.cbz" >
+                </data>
+                <data 
+                     android:scheme="file"
+                     android:pathPattern=".*\\.acv" >
+                </data>
+                 <data 
+                     android:scheme="file"
+                     android:pathPattern=".*\\.zip" >
+                </data>
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
Some file explorers like Solid Explorer are currently only aware of ZIP-files. And as ACV handles these anyway I added the corresponding intent-filter. I also added the file pattern match for the now four filetypes in case a device is missing the mime-types.
