### PR TITLE
Avoid EBUSY when loading images from temp dir

### DIFF
--- a/src/net/robotmedia/acv/ui/ComicViewerActivity.java
+++ b/src/net/robotmedia/acv/ui/ComicViewerActivity.java
@@ -1169,8 +1169,14 @@ public class ComicViewerActivity extends ExtendedActivity implements OnGestureLi
 		
 		if (emptyTemp) {
 			File tempDirectory = new File(Environment.getExternalStorageDirectory(), Constants.TEMP_PATH);
-			if(tempDirectory.exists())
-				FileUtils.deleteDirectory(tempDirectory);
+			if(tempDirectory.exists()) {
+				File[] files = tempDirectory.listFiles();
+				if (files != null) {
+					for (File f : files) {
+						f.delete();
+					}
+				}
+			}
 		}
 		if (comic != null) {
 			comic.destroy();


### PR DESCRIPTION
Rather than deleting the temp directory, delete all of the files inside that directory.  On some Androids (5.0 on my Nexus 4, never on previous versions) subsequent accesses to the deleted directory will return EBUSY which means files don't load properly.
